### PR TITLE
Backport the docker-wait-ready script from the newer docker cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 metadata
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.53.0
+
+* Backport the docker-wait-ready script from the newer docker cookbook
+
 ## 0.51.0
 
 * Rename helper class to avoid collisions with mainline docker cookbook

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bflad417@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Docker'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.52.1'
+version '0.53.0'
 
 recipe 'docker', 'Installs/Configures Docker'
 recipe 'docker-legacy::aufs', 'Installs/Loads AUFS Linux module'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,6 +49,20 @@ directory 'docker-graph' do
   not_if { node['docker']['graph'].nil? }
 end
 
+directory '/usr/lib/docker'
+
+template '/usr/lib/docker/docker-wait-ready' do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  variables(service_timeout: 20, docker_cmd: 'docker')
+end
+
+execute 'docker-wait-ready' do
+  command '/usr/lib/docker/docker-wait-ready'
+  action :nothing
+end
+
 unless node['docker']['install_type'] == 'package'
   if node['platform'] == 'ubuntu' && Chef::VersionConstraint.new('< 13.10').include?(node['platform_version'])
     include_recipe "docker-legacy::#{node['docker']['storage_driver']}" if node['docker']['storage_driver']

--- a/recipes/upstart.rb
+++ b/recipes/upstart.rb
@@ -7,6 +7,12 @@ template docker_upstart_conf_file do
   mode '0600'
   owner 'root'
   group 'root'
+  variables(
+    docker_wait_ready: '/usr/lib/docker/docker-wait-ready',
+    docker_socker: '/var/run/docker.sock'
+  )
+  notifies :stop, "service[#{docker_service}]", :immediately
+  notifies :start, "service[#{docker_service}]", :immediately
 end
 
 template docker_settings_file do

--- a/templates/default/docker-wait-ready.erb
+++ b/templates/default/docker-wait-ready.erb
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+i=0
+while [ $i -lt <%= @service_timeout * 2 %> ]; do
+  <%= @docker_cmd %> ps | head -n 1 | grep ^CONTAINER > /dev/null 2>&1
+  [ $? -eq 0 ] && break
+  ((i++))
+  sleep 0.5
+done
+[ $i -eq <%= @service_timeout * 2 %> ] && exit 1
+exit 0

--- a/templates/default/docker.conf.erb
+++ b/templates/default/docker.conf.erb
@@ -40,19 +40,18 @@ script
 	exec "$DOCKER" -d $DOCKER_OPTS
 end script
 
-# Don't emit "started" event until docker.sock is ready.
+# Don't emit "started" event until the docker socket is ready.
 # See https://github.com/docker/docker/issues/6647
 post-start script
-	DOCKER_OPTS=
-	if [ -f /etc/default/$UPSTART_JOB ]; then
-		. /etc/default/$UPSTART_JOB
-	fi
-	if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
-		while ! [ -e /var/run/docker.sock ]; do
-			initctl status $UPSTART_JOB | grep -q "stop/" && exit 1
-			echo "Waiting for /var/run/docker.sock"
-			sleep 0.1
-		done
-		echo "/var/run/docker.sock is up"
-	fi
+  DOCKER_OPTS=
+  if [ -f /etc/default/$UPSTART_JOB ]; then
+    . /etc/default/$UPSTART_JOB
+  fi
+  <%= @docker_wait_ready %>
+  if [ $? -eq 0 ]; then
+    echo "<%= @docker_socket %> is up"
+  else
+    echo "<%= @docker_socket %> failed to start"
+    exit 1
+  fi
 end script

--- a/test/cookbooks/docker_test/metadata.rb
+++ b/test/cookbooks/docker_test/metadata.rb
@@ -6,4 +6,4 @@ description      'Installs/Configures docker_test'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.5.1'
 
-depends 'docker'
+depends 'docker-legacy'

--- a/test/cookbooks/docker_test/recipes/binary.rb
+++ b/test/cookbooks/docker_test/recipes/binary.rb
@@ -1,3 +1,3 @@
 node.set['docker']['install_type'] = "binary"
 
-include_recipe "docker"
+include_recipe "docker-legacy"

--- a/test/cookbooks/docker_test/recipes/default.rb
+++ b/test/cookbooks/docker_test/recipes/default.rb
@@ -1,1 +1,1 @@
-include_recipe "docker"
+include_recipe "docker-legacy"


### PR DESCRIPTION
Between our ancient version and now, they switched to checking whether Docker's actually up and responding rather than just whether the socket file exists. Let's see if this fixes the issue with Dnsmasq trying to start before Docker is truly "started".
