### PR TITLE
Increase the Docker daemon timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.52.2
+
+* Increase the Docker daemon timeout
+
 ## 0.51.0
 
 * Rename helper class to avoid collisions with mainline docker cookbook

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ These attributes are under the `node['docker']` namespace.
 
 Attribute | Description | Type | Default
 ----------|-------------|------|--------
-docker_daemon_timeout | Timeout to wait for the docker daemon to start in seconds for LWRP commands | Fixnum | 10
+docker_daemon_timeout | Timeout to wait for the docker daemon to start in seconds for LWRP commands | Fixnum | 20
 
 #### docker_container Attributes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -186,7 +186,7 @@ default['docker']['tmpdir'] = nil
 
 # LWRP attributes
 
-default['docker']['docker_daemon_timeout'] = 10
+default['docker']['docker_daemon_timeout'] = 20
 
 ## docker_container attributes
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bflad417@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Docker'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.52.1'
+version '0.52.2'
 
 recipe 'docker', 'Installs/Configures Docker'
 recipe 'docker-legacy::aufs', 'Installs/Loads AUFS Linux module'


### PR DESCRIPTION
It takes more than 10s (potentially up to 30, but let's start with 20)
for Docker to start up the first time while it sets up the devicemapper
stuff. The Mesos instances are generally okay with that, but the Docker
registries try to pull down an image immediately after installing
Docker, so they end up timing out.